### PR TITLE
Post format styling

### DIFF
--- a/formats/format-chat.php
+++ b/formats/format-chat.php
@@ -4,11 +4,11 @@
  * //formats/format-chat.php
  *******************************************************************************
  *
- * Post format for a chat (dump) post. 
+ * Post format for a chat (dump) post.
  *
  * CODEX REF
  * https://developer.wordpress.org/themes/functionality/post-formats/
- * 
+ *
  * @author
  * @copyright
  * @link

--- a/formats/format-chat.php
+++ b/formats/format-chat.php
@@ -19,7 +19,7 @@
 **/
 ?>
 
-<article>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
     <section>
         <?php the_content(); ?>
     </section>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -198,6 +198,15 @@ blockquote p {
 }
 
 /*****************************
+ ~~ Post Format: chat
+*****************************/
+
+.post_format-post-format-chat {
+    background: #f9f9f9;
+	font-family:monospace;
+}
+
+/*****************************
  ~~ admin
 *****************************/
 


### PR DESCRIPTION
This adds the background color of blockquote element already in the theme, to keep it consistent, while also adding monospaced font suggested by WordPress:

> A chat in particular will probably tend towards a monospaced type display, in many cases. With some styling on the .format-chat, you can make it display the content of the post using a monospaced font, perhaps inside a gray background div or similar, thus distinguishing it visually as a chat session.