### PR TITLE
Added Docker Compose Development Environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+web:
+  image: wordpress
+  links:
+    - mysql
+  environment:
+    - WORDPRESS_DB_PASSWORD=password
+  ports:
+    - "8080:80"
+  working_dir: /var/www/html
+  volumes:
+    - ./:/var/www/html/wp-content/themes/BigBooty/
+mysql:
+  image: mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD=password
+    - MYSQL_DATABASE=wordpress


### PR DESCRIPTION
Added docker compose development environment with theme added to the wordpress installation.
User just needs to visit `localhost:8080`, install the site, install the woocommerce plugin, activate the theme and start development.
As the theme is used as a volume in the docker container, and changes in the theme will reflect in the site too.